### PR TITLE
Exit with status zero on normal termination

### DIFF
--- a/src/lumpy/lumpy.cpp
+++ b/src/lumpy/lumpy.cpp
@@ -729,5 +729,5 @@ int main(int argc, char* argv[])
 	}
 	//}}}
 
-	return 1;
+	return 0;
 }


### PR DESCRIPTION
I could me misunderstanding the expected flow here, but lumpy keeps exiting with a nonzero error status although it appears to have done all it should. Main should return a nonzero status only with abnormal termination.
