### PR TITLE
leak fix in SV_BreakPoint

### DIFF
--- a/src/lumpy/SV_BreakPoint.cpp
+++ b/src/lumpy/SV_BreakPoint.cpp
@@ -342,6 +342,7 @@ merge(SV_BreakPoint *p)
 		l_end_sum+=tmp_bp->interval_l.i.end;
 		r_start_sum+=tmp_bp->interval_r.i.start;
 		r_end_sum+=tmp_bp->interval_r.i.end;
+		delete(tmp_bp);
 	}
 
 	CHR_POS l_merged_start, l_merged_end, r_merged_start, r_merged_end;


### PR DESCRIPTION
This addresses a memory leak where a temporary breakpoint is made but not deleted. Hooray for valgrind and one-line fixes!
