### PR TITLE
Read group awareness

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,13 @@ Weight of each piece of evidence from this sample.
         id:<sample id>
 
 Sample id.
+::
+
+        read_group:<string>
+
+Read group IDs to consider from the BAM file. This parameter may be specified
+multiple times for multiple read groups. In the absence of this parameter,
+all read groups are considered.
 
 Paired-end options
 ::
@@ -254,7 +261,13 @@ Weight of each piece of evidence from this sample.
         id:<sample id>
 
 Sample id.
+::
 
+        read_group:<string>
+
+Read group IDs to consider from the BAM file. This parameter may be specified
+multiple times for multiple read groups. In the absence of this parameter,
+all read groups are considered.
 
 
 BEDPE (general interface) options

--- a/src/lumpy/SV_BamReader.h
+++ b/src/lumpy/SV_BamReader.h
@@ -34,7 +34,7 @@ class SV_BamReader : public SV_EvidenceReader
 {
 	private:
 		bool is_open, has_next_alignment;
-		map<string, SV_EvidenceReader*> *bam_evidence_readers;
+		map<pair<string,string>, SV_EvidenceReader*> *bam_evidence_readers;
 		BamMultiReader bam_reader;
 		BamAlignment bam;
 		string header;
@@ -46,7 +46,7 @@ class SV_BamReader : public SV_EvidenceReader
 		RefVector refs;
 		SV_BamReader();
 		~SV_BamReader();
-		SV_BamReader(map<string, SV_EvidenceReader*> *_bam_evidence_readers);
+		SV_BamReader(map<pair<string,string>, SV_EvidenceReader*> *_bam_evidence_readers);
 
 		bool add_param(char *param, char *val);
 		string check_params();

--- a/src/lumpy/SV_InterChromBamReader.h
+++ b/src/lumpy/SV_InterChromBamReader.h
@@ -34,7 +34,7 @@ class SV_InterChromBamReader : public SV_EvidenceReader
 {
 	private:
 		bool is_open, has_next_alignment;
-		map<string, SV_EvidenceReader*> *bam_evidence_readers;
+		map<pair<string,string>, SV_EvidenceReader*> *bam_evidence_readers;
 		BamReader bam_reader;
 		RefVector refs;
 		BamAlignment bam;
@@ -55,7 +55,7 @@ class SV_InterChromBamReader : public SV_EvidenceReader
 		~SV_InterChromBamReader();
 		SV_InterChromBamReader(
 				string _inter_chrom_bam_file,
-				map<string, SV_EvidenceReader*> *_bam_evidence_readers);
+				map<pair<string,string>, SV_EvidenceReader*> *_bam_evidence_readers);
 
 		void process_input_chr_pos(string primary_chr,
 								   string secondary_chr,

--- a/src/lumpy/SV_PairReader.cpp
+++ b/src/lumpy/SV_PairReader.cpp
@@ -34,6 +34,7 @@ SV_PairReader(struct pair_end_parameters pair_end_param)
     weight = pair_end_param.weight;
     id = pair_end_param.id;
     min_mapping_threshold = pair_end_param.min_mapping_threshold;
+    read_group = pair_end_param.read_group;
 }
 //}}}
 
@@ -118,6 +119,8 @@ add_param(char *param, char *val)
         id = atoi(val);
     else if ( strcmp("min_mapping_threshold", param) == 0 )
         min_mapping_threshold = atoi(val);
+    else if ( strcmp("read_group", param) == 0 )
+        read_group.push_back(val);
     else
         return false;
 
@@ -143,6 +146,7 @@ get_pair_end_parameters()
     pair_end_param.weight = weight;
     pair_end_param.id = id;
     pair_end_param.min_mapping_threshold = min_mapping_threshold;
+    pair_end_param.read_group = read_group;
 
     return pair_end_param;
 }
@@ -161,6 +165,7 @@ set_statics()
     SV_Pair::insert_Z = discordant_z;
     SV_Pair::back_distance = back_distance;
     SV_Pair::read_length = read_length;
+    SV_Pair::read_group = read_group;
 
     int distro_size;
     unsigned int start, end;

--- a/src/lumpy/SV_PairReader.h
+++ b/src/lumpy/SV_PairReader.h
@@ -41,6 +41,7 @@ struct pair_end_parameters {
 				 min_mapping_threshold;
 	int weight;
 	int id;
+        vector<string> read_group;
 };
 //}}}
 
@@ -57,6 +58,7 @@ class SV_PairReader : public SV_EvidenceReader
 					 min_mapping_threshold;
 		int weight;
 		int id;
+		vector<string> read_group;
 		bool is_open,
 			 have_next_alignment;
 		double *histo;

--- a/src/lumpy/SV_SplitReadReader.cpp
+++ b/src/lumpy/SV_SplitReadReader.cpp
@@ -72,6 +72,8 @@ add_param(char *param, char *val)
 		min_mapping_threshold = atoi(val);
 	else if ( strcmp("min_clip", param) == 0 )
 		min_clip = atoi(val);
+	else if ( strcmp("read_group", param) == 0 )
+		read_group.push_back(val);
 	else 
 		return false;
 

--- a/src/lumpy/SV_SplitReadReader.h
+++ b/src/lumpy/SV_SplitReadReader.h
@@ -38,6 +38,7 @@ struct split_read_parameters {
                  min_clip;
 	int weight;
 	int id;
+	vector<string> read_group;
 };
 //}}}
 
@@ -51,6 +52,7 @@ class SV_SplitReadReader : public SV_EvidenceReader
                      min_clip;
 		int weight;
 		int id;
+		vector<string> read_group;
 		bool is_open,
 			 have_next_alignment;
 

--- a/src/lumpy/lumpy.cpp
+++ b/src/lumpy/lumpy.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
                     char *val = strtok_r(NULL, ":", &brkb);
 
                     if (val == NULL) {
-                        cerr << "Parameter requied for " << param << endl;
+                        cerr << "Parameter required for " << param << endl;
                         ShowHelp();
                     }
 

--- a/src/lumpy/lumpy.cpp
+++ b/src/lumpy/lumpy.cpp
@@ -89,11 +89,12 @@ void ShowHelp(void)
          "\t-t"	"\ttemp file prefix, must be to a writeable directory" <<
          endl <<
          "\t-sr"     "\tbam_file:<file name>," << endl <<
-         "\t\tback_distance:<distance>" << endl <<
-         "\t\tmin_mapping_threshold:<mapping quality>" << endl <<
-         "\t\tweight:<sample weight>" << endl <<
-         "\t\tid:<sample id>" << endl <<
-         "\t\tmin_clip:<minimum clip length>" << endl <<
+         "\t\tback_distance:<distance>," << endl <<
+         "\t\tmin_mapping_threshold:<mapping quality>," << endl <<
+         "\t\tweight:<sample weight>," << endl <<
+         "\t\tid:<sample id>," << endl <<
+         "\t\tmin_clip:<minimum clip length>," << endl <<
+         "\t\tread_group:<string>" << endl <<
          endl <<
          "\t-pe"     "\tbam_file:<file name>," << endl <<
          "\t\thisto_file:<file name>," << endl <<
@@ -102,13 +103,14 @@ void ShowHelp(void)
          "\t\tread_length:<length>," << endl <<
          "\t\tmin_non_overlap:<length>," << endl <<
          "\t\tdiscordant_z:<z value>," << endl <<
-         "\t\tback_distance:<distance>" << endl <<
-         "\t\tmin_mapping_threshold:<mapping quality>" << endl <<
-         "\t\tweight:<sample weight>" << endl <<
-         "\t\tid:<sample id>" << endl <<
+         "\t\tback_distance:<distance>," << endl <<
+         "\t\tmin_mapping_threshold:<mapping quality>," << endl <<
+         "\t\tweight:<sample weight>," << endl <<
+         "\t\tid:<sample id>," << endl <<
+         "\t\tread_group:<string>" << endl <<
          endl <<
          "\t-bedpe"  "\tbedpe_file:<bedpe file>," << endl <<
-         "\t\tweight:<sample weight>" << endl <<
+         "\t\tweight:<sample weight>," << endl <<
          "\t\tid:<sample id>" << endl <<
          endl;
     // end the program here
@@ -156,7 +158,7 @@ int main(int argc, char* argv[])
 
     //{{{ do some parsing and setup
     vector<SV_EvidenceReader*> evidence_readers;
-    map<string, SV_EvidenceReader*> bam_evidence_readers;
+    map<pair<string,string>, SV_EvidenceReader*> bam_evidence_readers;
 
     for(int i = 1; i < argc; i++) {
         int parameterLength = (int)strlen(argv[i]);
@@ -191,7 +193,7 @@ int main(int argc, char* argv[])
             string msg = pe_r->check_params();
             if ( msg.compare("") == 0 ) {
                 // Add to list of readers
-                // Set the ditro map
+                // Set the distro map
 
                 pe_r->initialize();
                 SV_Evidence::distros[pe_r->sample_id] =
@@ -208,7 +210,17 @@ int main(int argc, char* argv[])
                 ShowHelp();
             }
 
-            bam_evidence_readers[pe_r->get_source_file_name()] = pe_r;
+	    // create SV_EvidenceReaders by (BAM, read_group) pairs
+	    if (pe_r->read_group.size() == 0)
+	        bam_evidence_readers[pair<string,string> (pe_r->get_source_file_name(),"")] = pe_r;
+	    else {
+	        for (vector<string>::iterator it = pe_r->read_group.begin();
+		     it != pe_r->read_group.end();
+		     ++it) {
+		    pair<string,string> ev_pair (pe_r->get_source_file_name(),*it);
+		    bam_evidence_readers[ev_pair] = pe_r;
+		}
+	    }
 
             i++;
             //}}}
@@ -311,8 +323,17 @@ int main(int argc, char* argv[])
                 ShowHelp();
             }
 
-            //bam_files.push_back(sr_r->get_source_file_name());
-            bam_evidence_readers[sr_r->get_source_file_name()] = sr_r;
+	    // create SV_EvidenceReaders by (BAM, read_group) pairs
+	    if (sr_r->read_group.size() == 0)
+	        bam_evidence_readers[pair<string,string> (sr_r->get_source_file_name(),"")] = sr_r;
+	    else {
+	        for (vector<string>::iterator it = sr_r->read_group.begin();
+		     it != sr_r->read_group.end();
+		     ++it) {
+		    pair<string,string> ev_pair (sr_r->get_source_file_name(),*it);
+		    bam_evidence_readers[ev_pair] = sr_r;
+		}
+	    }
 
             i++;
             //}}}


### PR DESCRIPTION
These modifications make LUMPY read group aware, simplifying integration into the SpeedSeq pipeline. Mainly, allows us to merge all splitters and discordant files from different libraries on a per-sample basis prior to running LUMPY.

Users may now specify one or more read groups to consider in the -pe and -sr command line arguments of LUMPY. The intended usage is for each -pe blob to process a single library (potentially with multiple read groups), drawing from the proper insert size distribution. If there are multiple libraries in a single BAM file, then the -pe blob can be called multiple times, each with read groups from the unique library while repeating the BAM file. If the "read_group" parameter is omitted, LUMPY behaves exactly as it did before: considering all read_groups in the BAM file.

Example:
```
lumpy \
    -mw 4 \
    -tt 0 \
    -pe bam_file:A-CUHS-CU000063.merged.discordants.bam,histo_file:2893594432.x4.histo,mean:230.216068583,stdev:27.0862036746,read_length:100,min_non_overlap:100,discordant_z:5,back_distance:10,weight:1,id:100,min_mapping_threshold:20,read_group:2893594432 \
    -pe bam_file:A-CUHS-CU000063.merged.discordants.bam,histo_file:2893594429.x4.histo,mean:473.270630769,stdev:100.489159512,read_length:100,min_non_overlap:100,discordant_z:5,back_distance:10,weight:1,id:110,min_mapping_threshold:20,read_group:2893594429 \
    -pe bam_file:A-CUHS-CU000063.merged.discordants.bam,histo_file:2893594379.x4.histo,mean:330.345984874,stdev:37.3689979312,read_length:100,min_non_overlap:100,discordant_z:5,back_distance:10,weight:1,id:120,min_mapping_threshold:20,read_group:2893594379 \
    -sr bam_file:A-CUHS-CU000063.merged.splitters.bam,back_distance:10,min_mapping_threshold:20,weight:1,id:101,min_clip:20 \
    > A-CUHS-CU000063.multi.lumpy
```

By my testing, these modifications do not affect speed:
 8d7eb49ce18496217bf2f7d088c9337cb6f88f68: 3028.69 sec
588046880592ebc4aaf5cf299cf6956f8c699a59: 3034.13 sec