### PR TITLE
Initialize SV_BedpeReader::distro_size in constructor

### DIFF
--- a/src/lumpy/SV_BedpeReader.cpp
+++ b/src/lumpy/SV_BedpeReader.cpp
@@ -24,6 +24,7 @@ SV_BedpeReader()
 {
     bedpe_file = "";
     //distro_file = "";
+    distro_size = 0;
     weight = 0;
     id = -1;
     sample_id = SV_EvidenceReader::counter;


### PR DESCRIPTION
SV_BedpeReader::distro_size wasn't being initialized. This was causing a segfault in some cases on SV_Bedpe.cpp::get_bp_interval_probability line 182.