### PR TITLE
Removed extra trailing slash from lumpy path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export CXX		= g++
 export CXXFLAGS = -Wall -O2 -D_FILE_OFFSET_BITS=64 -fPIC
 export LIBS		= -lz
 export BT_ROOT  = src/utils/BamTools/
-export MKFILE_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export MKFILE_DIR = $(abspath $(PWD))
 
 SUBDIRS = $(SRC_DIR)/lumpy
 


### PR DESCRIPTION
Hi, there was an error in the makefile where you had an extra slash added to the lumpy path, ie: `path/to/lumpy-sv//scripts` instead of `path/to/lumpy-sv/scripts`, this fixes the problem.
