### PR TITLE
Avoid pipefail issue with head during insert stats

### DIFF
--- a/scripts/lumpyexpress
+++ b/scripts/lumpyexpress
@@ -406,7 +406,6 @@ else
 	    # calculate read length if not provided
 	    set +o pipefail
 	    LIB_READ_LENGTH_LIST+=(`$SAMT view ${FULL_BAM_LIST[$i]} | head -n 10000 | gawk 'BEGIN { MAX_LEN=0 } { LEN=length($10); if (LEN>MAX_LEN) MAX_LEN=LEN } END { print MAX_LEN }'`)
-	    set -o pipefail
 	    echo "Library read groups: ${LIB_RG_LIST[$j]}"
 	    echo "Library read length: ${LIB_READ_LENGTH_LIST[$j]}"
 	    $SAMT_STREAM ${FULL_BAM_LIST[$i]} \
@@ -415,6 +414,7 @@ else
 		| tail -n 1000000 \
 		| $PYTHON $PAIREND_DISTRO -r ${LIB_READ_LENGTH_LIST[$j]} -X 4 -N 1000000 -o ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).x4.histo \
 		> ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).insert.stats
+	    set -o pipefail
 	done
 	echo "done"
 


### PR DESCRIPTION
When calculating insert stats the implicit head command from
bamfilterrg causes the pipe to return a 141 error, failing any
calling tool that checks error codes. This allows skipping pipefail on
this step to avoid the error.