### PR TITLE
Fix argument order for static library linking

### DIFF
--- a/src/filter/Makefile
+++ b/src/filter/Makefile
@@ -1,4 +1,4 @@
 
 all:
-	$(CC) -I../../lib/htslib/ -lz -lpthread -o lumpy_filter ../../lib/htslib/libhts.a filter.c 
+	$(CC) -I../../lib/htslib/ -lz -lpthread -o lumpy_filter filter.c ../../lib/htslib/libhts.a
 

--- a/src/filter/Makefile
+++ b/src/filter/Makefile
@@ -1,4 +1,4 @@
 
 all:
-	$(CC) -I../../lib/htslib/ -lz -lpthread -o lumpy_filter filter.c ../../lib/htslib/libhts.a
+	$(CC) -I../../lib/htslib/ -o lumpy_filter filter.c ../../lib/htslib/libhts.a -lpthread -lz
 


### PR DESCRIPTION
Fixed the argument order (really just needed to flip filter.c and libhts.a) so that static library linking works properly.
This should fix the current (as of 2016/10/28) Travis-CI failure.

Reference for fix is the second answer from:
http://stackoverflow.com/questions/6578484/telling-gcc-directly-to-link-a-library-statically