### PR TITLE
Make all lumpy python scripts python2.7 and python3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "2.7"
-script: 
+  - "3.5"
+script:
     - source activate travis
     - ./scripts/lumpyexpress -h
     - python scripts/cnvanator_to_bedpes.py --cnvkit  -b 100 --del_o delo2 --dup_o dupo2 -c data/example.cns

--- a/scripts/bedpe_sort.py
+++ b/scripts/bedpe_sort.py
@@ -54,4 +54,4 @@ else:
 for c in order:
     if c in B:
         for l in sorted(B[c], key=itemgetter(0)):
-            print l[1]
+            print(l[1])

--- a/scripts/check_sorting.py
+++ b/scripts/check_sorting.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 if len(sys.argv) < 2:
-    print 'usage:' + sys.argv[0] + ' <bam 1> <bam 2> <..>'
+    print('usage:' + sys.argv[0] + ' <bam 1> <bam 2> <..>')
     exit(1)
 
 order = []
@@ -13,7 +13,7 @@ order = []
 
 for i in range(1,len(sys.argv)):
     bam_file = sys.argv[i]
-    print bam_file
+    print(bam_file)
 
     p = subprocess.Popen(\
             ['samtools', 'view', '-H', bam_file], \
@@ -48,19 +48,19 @@ for i in range(1,len(sys.argv)):
                 curr_chrom_index = order.index(chrom)
                 curr_pos = -1
             elif order.index(chrom) < curr_chrom_index:
-                print 'out of order:\t' + l + '\toccurred after\t' + \
-                        order[curr_chrom_index] + '\t' + str(curr_pos)
+                print('out of order:\t' + l + '\toccurred after\t' + \
+                        order[curr_chrom_index] + '\t' + str(curr_pos))
                 broke = True
                 break
 
             if pos > curr_pos:
                 curr_pos = pos
             elif pos < curr_pos:
-                print 'out of order:\t' + l + '\toccurred after\t' + \
-                        order[curr_chrom_index] + '\t' + str(curr_pos)
+                print('out of order:\t' + l + '\toccurred after\t' + \
+                        order[curr_chrom_index] + '\t' + str(curr_pos))
                 broke = True
                 break
     if not broke:
-        print "in order"
+        print("in order")
 
 

--- a/scripts/extract-sites.py
+++ b/scripts/extract-sites.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import sys
 import gzip
 import collections

--- a/scripts/extractSplitReads_BwaMem
+++ b/scripts/extractSplitReads_BwaMem
@@ -14,7 +14,7 @@ def extractSplitsFromBwaMem(inFile,numSplits,includeDups,minNonOverlap):
 	for line in data:
 		split = 0
 		if line[0] == '@':
-			print line.strip()
+			print(line.strip())
 			continue
 		samList = line.strip().split('\t')
 		sam = SAM(samList)
@@ -29,10 +29,10 @@ def extractSplitsFromBwaMem(inFile,numSplits,includeDups,minNonOverlap):
 					mateFlag = int(0)
 					if mate[2]=="-": mateFlag = int(16)
 		if split:
-			read1 = sam.flag & 64 
+			read1 = sam.flag & 64
 			if read1 == 64: tag = "_1"
 			else: tag="_2"
-			samList[0] = sam.query + tag 
+			samList[0] = sam.query + tag
 			readCigar = sam.cigar
 			readCigarOps = extractCigarOps(readCigar,sam.flag)
 			readQueryPos = calcQueryPosFromCigar(readCigarOps)
@@ -43,7 +43,7 @@ def extractSplitsFromBwaMem(inFile,numSplits,includeDups,minNonOverlap):
 			nonOverlap2 = 1 + mateQueryPos.qePos - mateQueryPos.qsPos - overlap
 			mno = min(nonOverlap1, nonOverlap2)
 			if mno >= minNonOverlap:
-				print "\t".join(samList)
+				print("\t".join(samList))
 
 #--------------------------------------------------------------------------------------------------
 # functions
@@ -82,7 +82,7 @@ class SAM (object):
 					return int(tagParts[2],16);
 				return tagParts[2];
 		return None;
-	
+
 #-----------------------------------------------
 cigarPattern = '([0-9]+[MIDNSHP])'
 cigarSearch = re.compile(cigarPattern)
@@ -121,9 +121,9 @@ def calcQueryPosFromCigar(cigarOps):
 	qsPos = 0
 	qePos = 0
 	qLen  = 0
-	# if first op is a H, need to shift start position 
-	# the opPosition counter sees if the for loop is looking at the first index of the cigar object    
-	opPosition = 0  
+	# if first op is a H, need to shift start position
+	# the opPosition counter sees if the for loop is looking at the first index of the cigar object
+	opPosition = 0
 	for cigar in cigarOps:
 		if opPosition == 0 and (cigar.op == 'H' or cigar.op == 'S'):
 			qsPos += cigar.length
@@ -164,34 +164,34 @@ def calcQueryOverlap(s1,e1,s2,e2):
 
 class Usage(Exception):
 	def __init__(self, msg):
-		self.msg = msg		
+		self.msg = msg
 
 def main():
-	
+
 	usage = """%prog -i <file>
 
 extractSplitReads_BwaMem v0.1.0
-Author: Ira Hall	
+Author: Ira Hall
 Description: Get split-read alignments from bwa-mem in lumpy compatible format. Ignores reads marked as duplicates.
-Works on read or position sorted SAM input. Tested on bwa mem v0.7.5a-r405. 
+Works on read or position sorted SAM input. Tested on bwa mem v0.7.5a-r405.
 	"""
 	parser = OptionParser(usage)
-	
-	parser.add_option("-i", "--inFile", dest="inFile", 
+
+	parser.add_option("-i", "--inFile", dest="inFile",
 		help="A SAM file or standard input (-i stdin).",
 		metavar="FILE")
-	parser.add_option("-n", "--numSplits", dest="numSplits", default=2, type = "int", 
+	parser.add_option("-n", "--numSplits", dest="numSplits", default=2, type = "int",
 		help="The maximum number of split-read mappings to allow per read. Reads with more are excluded. Default=2",
 		metavar="INT")
-	parser.add_option("-d", "--includeDups", dest="includeDups", action="store_true",default=0, 
+	parser.add_option("-d", "--includeDups", dest="includeDups", action="store_true",default=0,
 		help="Include alignments marked as duplicates. Default=False")
-	parser.add_option("-m", "--minNonOverlap", dest="minNonOverlap", default=20, type = "int", 
+	parser.add_option("-m", "--minNonOverlap", dest="minNonOverlap", default=20, type = "int",
 		help="minimum non-overlap between split alignments on the query (default=20)",
 		metavar="INT")
 	(opts, args) = parser.parse_args()
 	if opts.inFile is None:
 		parser.print_help()
-		print
+		print()
 	else:
 		try:
 			extractSplitsFromBwaMem(opts.inFile, opts.numSplits, opts.includeDups, opts.minNonOverlap)
@@ -199,5 +199,5 @@ Works on read or position sorted SAM input. Tested on bwa mem v0.7.5a-r405.
 			sys.stderr.write("IOError " + str(err) + "\n");
 			return
 if __name__ == "__main__":
-	sys.exit(main()) 
-	
+	sys.exit(main())
+

--- a/scripts/get_coverages.py
+++ b/scripts/get_coverages.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 if len(sys.argv) < 2:
-    print 'usage:' + sys.argv[0] + ' <in bam 1> <in bam 2> <..>'
+    print('usage:' + sys.argv[0] + ' <in bam 1> <in bam 2> <..>')
     exit(1)
 
 for i in range(1,len(sys.argv)):
@@ -54,14 +54,14 @@ for i in range(1,len(sys.argv)):
     for l in f:
         a = l.rstrip().split('\t')
         if float(a[3]) > 0:
-            C.append(float(a[3])) 
+            C.append(float(a[3]))
             W.append((float(a[2])-float(a[1]))/total_len)
     min_c = min(C)
     max_c = max(C)
     mean_c = np.average(C,weights=W)
     stdev_c = np.std(C)
-    print coverage_file + \
+    print(coverage_file + \
             '\tmin:' + str(min_c) + \
             '\tmax:' + str(max_c) + \
-            '\tmean(non-zero):' + str(mean_c) 
+            '\tmean(non-zero):' + str(mean_c))
     f.close()

--- a/scripts/get_exclude_regions.py
+++ b/scripts/get_exclude_regions.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 if len(sys.argv) < 3:
-    print 'usage:' + sys.argv[0] + ' <max> <out file> <in bam 1> <in bam 2> <..>'
+    print('usage:' + sys.argv[0] + ' <max> <out file> <in bam 1> <in bam 2> <..>')
     exit(1)
 
 max_c = int(sys.argv[1])
@@ -24,7 +24,7 @@ for i in range(3,len(sys.argv)):
             o.write(l)
     f.close()
 o.close()
-            
+
 p = subprocess.Popen(\
         'cat .exclude.tmp | ' \
         'sort -S 20G -k1,1 -k2,2n | ' \

--- a/scripts/l_bp.py
+++ b/scripts/l_bp.py
@@ -1,5 +1,4 @@
 import sys
-from sets import Set
 import re
 
 def find_all(a_str, sub):
@@ -34,7 +33,7 @@ def parse_vcf(vcf_file_name, vcf_lines, vcf_headers, add_sname=True):
                     A[7] += ';' + 'SNAME=' + ','.join(samples)
                     l = '\t'.join(A)
 
-                
+
                 if 'SVTYPE=BND' in A[7]:
                     m = re.search(r"(\[|\])(.*)(\[|\])",A[4])
                     o_chr,o_pos = m.group(2).split(':')
@@ -44,13 +43,13 @@ def parse_vcf(vcf_file_name, vcf_lines, vcf_headers, add_sname=True):
                         pos_s = A[7].find('++:')
 
                         if neg_s > 0:
-                            neg_e = neg_s + A[7][neg_s:].find(';') 
+                            neg_e = neg_s + A[7][neg_s:].find(';')
                             pre=A[7][:neg_s]
                             mid=A[7][neg_s:neg_e]
                             post=A[7][neg_e:]
                             A[7] = pre + '++:0,' + mid + post
                         else:
-                            pos_e = pos_s + A[7][pos_s:].find(';') 
+                            pos_e = pos_s + A[7][pos_s:].find(';')
                             pre=A[7][:pos_s]
                             mid=A[7][pos_s:pos_e]
                             post=A[7][pos_e:]
@@ -91,7 +90,7 @@ def split_v(l):
 
     start_r = pos_r + int(m['CIEND'].split(',')[0])
     end_r = pos_r + int(m['CIEND'].split(',')[1])
-        
+
     strands = m['STRANDS']
 
     return [m['SVTYPE'],chr_l,chr_r,strands,start_l,end_l,start_r,end_r,m]
@@ -131,7 +130,7 @@ def header_line_cmp(l1, l2):
         return -1
 
     if l2[:12] == '##fileformat':
-        return 1 
+        return 1
 
     # make sure #CHROM ... is last
     if l1[1] != '#':
@@ -140,14 +139,14 @@ def header_line_cmp(l1, l2):
         return -1
 
     if l1.find('=') == -1:
-        return -1 
+        return -1
     if l2.find('=') == -1:
         return 1
 
     h1 = l1[:l1.find('=')]
     h2 = l2[:l2.find('=')]
     if h1 not in order:
-        return -1 
+        return -1
     if h2 not in order:
         return 1
     return cmp(order.index(h1),order.index(h2))
@@ -166,10 +165,10 @@ class breakpoint:
     sv_type = ''
 
     strands = ''
-    
+
     l = ''
 
-    def __init__(self, 
+    def __init__(self,
                  l,
                  percent_slop=0,
                  fixed_slop=0):
@@ -182,7 +181,7 @@ class breakpoint:
         self.start_l,\
         self.end_l,\
         self.start_r, \
-        self.end_r, 
+        self.end_r,
         m] = split_v(l)
 
         self.p_l = [float(x) for x in m['PRPOS'].split(',')]
@@ -218,7 +217,7 @@ class breakpoint:
             self.p_r = [float(x)/sum_p_r for x in new_p_r]
 
             # old_l = float(self.end_l - self.start_l + 1)
-            
+
             # self.start_l = max(0,self.start_l-l_slop)
             # self.end_l = self.end_l+l_slop
 
@@ -253,7 +252,7 @@ class breakpoint:
                                            self.end_l,\
                                            self.chr_r,\
                                            self.start_r, \
-                                           self.end_r, 
+                                           self.end_r,
                                            self.sv_type,\
                                            self.strands,\
                                            self.p_l,
@@ -304,7 +303,7 @@ def trim(A):
         if A[i] == 0:
             clip_end += 1
         else:
-            break               
+            break
     return [clip_start, clip_end]
 
 
@@ -338,11 +337,11 @@ def align_intervals(I):
             new_i = [0]*n + new_i
 
         if i[END] < end:
-            n = end - i[END] 
+            n = end - i[END]
             new_i = new_i + [0]*n
-        
+
         new_I.append(new_i)
-        
+
     return [start, end, new_I]
 
 
@@ -386,12 +385,12 @@ def bron_kerbosch(G, R, P, X):
     if (len(P) == 0) and (len(X) == 0):
         yield R
     for v in P:
-        V = Set([v])
-        N = Set([g[0] for g in G[v].edges])
-    
+        V = set([v])
+        N = set([g[0] for g in G[v].edges])
+
         for r in bron_kerbosch(G, \
                                R.union(V), \
-                               P.intersection(N), 
+                               P.intersection(N),
                                X.intersection(N)):
             yield r
 

--- a/scripts/l_merge.py
+++ b/scripts/l_merge.py
@@ -6,7 +6,6 @@ import numpy as np
 import glob
 from operator import add
 from optparse import OptionParser
-from sets import Set
 import l_bp
 
 def get_p(ls):
@@ -46,7 +45,7 @@ def print_var_line(l):
                 l_bp.split_v(l)
 
         STRAND_DICT = dict(x.split(':') for x in m['STRANDS'].split(','))
-        for o in STRAND_DICT.keys():
+        for o in STRAND_DICT:
             if STRAND_DICT[o] == '0':
                 del(STRAND_DICT[o])
         STRANDS = ','.join(['%s:%s' % (o,STRAND_DICT[o]) for o in STRAND_DICT])
@@ -152,11 +151,11 @@ def print_var_line(l):
 
         A[7] += ';MATEID=' + A[2] + '_2'
         A[2] += '_1'
-        print '\t'.join(A[:8])
-        print '\t'.join([str(o) for o in O])
+        print('\t'.join(A[:8]))
+        print('\t'.join([str(o) for o in O]))
 
     else:
-        print '\t'.join(A[:8])
+        print('\t'.join(A[:8]))
 
 def merge(BP, sample_order, v_id, use_product):
     #sys.stderr.write(str(len(BP)) + '\n')
@@ -217,9 +216,9 @@ def merge(BP, sample_order, v_id, use_product):
     #C = []
     #_G = G.copy()
     #while len(_G) != 0:
-    #    R = Set()
-    #    X = Set()
-    #    P = Set(_G.keys())
+    #    R = set()
+    #    X = set()
+    #    P = set(_G.keys())
     #    clique = [x for x in l_bp.bron_kerbosch(_G, R, P, X)]
     #    max_clique = sorted(clique, key=len)[0]
     #    sys.stderr.write(str(max_clique) +'\n')
@@ -236,7 +235,7 @@ def merge(BP, sample_order, v_id, use_product):
 
     BP.sort(key=lambda x: x.start_l)
 
-    BP_i = range(len(BP))
+    BP_i = list(range(len(BP)))
     C = []
 
     #print BP_i
@@ -598,7 +597,7 @@ def l_cluster(file_name, percent_slop=0, fixed_slop=0, use_product=False):
     #exit(1)
 
     for h in vcf_headers:
-        print h,
+        print(h, end=' ')
 
     BP_l = []
     BP_sv_type = ''
@@ -686,7 +685,7 @@ Version: ira_7
     #if opts.inFile is None or opts.configFile is None:
     if opts.inFile is None:
         parser.print_help()
-        print
+        print()
     else:
         try:
             l_cluster(opts.inFile,

--- a/scripts/l_sort.py
+++ b/scripts/l_sort.py
@@ -4,7 +4,6 @@ import numpy as np
 import glob
 from optparse import OptionParser
 import l_bp
-from sets import Set
 
 def main():
     usage ="""%prog <VCF file 1> <VCF file 2> ... <VCF file N>
@@ -16,7 +15,7 @@ Version: 0.01
 """
 
     if len(sys.argv) < 2:
-        exit(1)
+        exit(usage)
 
     vcf_file_names = sys.argv[1:]
 
@@ -41,7 +40,7 @@ Version: 0.01
     vcf_headers = list(vcf_headers)
     vcf_headers.sort(cmp=l_bp.header_line_cmp)
     for h in vcf_headers:
-        print h,
+        print(h, end=' ')
 
     vcf_lines.sort(cmp=l_bp.vcf_line_cmp)
     for v in vcf_lines:
@@ -64,7 +63,7 @@ Version: 0.01
 #                A[7] = pre + mid + ',--:0' + post
 #            print '\t'.join(A)
 #        else:
-            print v,
+            print(v, end=' ')
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/pairend_distro.py
+++ b/scripts/pairend_distro.py
@@ -48,8 +48,8 @@ parser.add_option("-m",
 
 def median(L):
     if len(L) % 2 == 1:
-        return L[len(L)/2]
-    mid = len(L) / 2 - 1
+        return L[int(len(L)/2)]  # cast to int since divisions always return floats in python3
+    mid = int(len(L) / 2) - 1
     return (L[mid] + L[mid+1]) / 2.0
 
 def unscaled_upper_mad(xs):
@@ -149,4 +149,4 @@ else:
 
     f.close()
 
-print('mean:' + str(mean) + '\tstdev:' + str(stdev))
+print(('mean:' + str(mean) + '\tstdev:' + str(stdev)))

--- a/scripts/prob_bedpe_to_bedgraph.py
+++ b/scripts/prob_bedpe_to_bedgraph.py
@@ -25,7 +25,7 @@ if not options.bedpe:
 
 f = open(options.bedpe,'r')
 
-print 'track type=bedGraph name="' + options.name + '"' 
+print('track type=bedGraph name="' + options.name + '"')
 
 for line in f:
     if line[0] == '#':
@@ -38,8 +38,8 @@ for line in f:
         if len(s_v) == 2:
             info[s_v[0]] = s_v[1]
 
-    L=[float(x) for x in info['PRPOS'].split(',')] 
-    R=[float(x) for x in info['PREND'].split(',')] 
+    L=[float(x) for x in info['PRPOS'].split(',')]
+    R=[float(x) for x in info['PREND'].split(',')]
 
     l_chr = v[0]
     l_start = int(v[1])
@@ -49,19 +49,19 @@ for line in f:
 
     c = 0
     for p in L:
-        print '\t'.join( [l_chr,
+        print('\t'.join( [l_chr,
                           str(l_start + c),
                           str(l_start + c + 1),
-                          str(p)])
+                          str(p)]))
         c+=1
 
     c = 0
     for p in R:
-        print '\t'.join( [r_chr,
+        print('\t'.join( [r_chr,
                           str(r_start + c),
                           str(r_start + c + 1),
-                          str(p)])
+                          str(p)]))
         c+=1
-    
+
 
 f.close()

--- a/scripts/vcfToBedpe
+++ b/scripts/vcfToBedpe
@@ -152,12 +152,12 @@ class Variant(object):
         self.active_formats = list()
         self.gts = dict()
         # make a genotype for each sample at variant
-        for i in xrange(len(self.sample_list)):
+        for i in range(len(self.sample_list)):
             s_gt = var_list[9+i].split(':')[0]
             s = self.sample_list[i]
             self.gts[s] = Genotype(self, s, s_gt)
         # import the existing fmt fields
-        for i in xrange(len(self.sample_list)):
+        for i in range(len(self.sample_list)):
             s = self.sample_list[i]
             for j in zip(var_list[8].split(':'), var_list[9+i].split(':')):
                 self.gts[s].set_format(j[0], j[1])
@@ -182,7 +182,7 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in self.info:
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
@@ -203,7 +203,7 @@ class Variant(object):
             sys.stderr.write('\nError: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
-        s = '\t'.join(map(str,[
+        s =[
             self.chrom,
             self.pos,
             self.var_id,
@@ -214,8 +214,8 @@ class Variant(object):
             self.get_info_string(),
             self.get_format_string(),
             '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
-        ]))
-        return s
+        ]
+        return '\t'.join(str(v) for v in s)
 
 class Genotype(object):
     def __init__(self, variant, sample_name, gt):
@@ -247,7 +247,7 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join([str(s) for s in g_list])
 
 # primary function
 def vcfToBedpe(vcf_file, bedpe_out):
@@ -256,7 +256,7 @@ def vcfToBedpe(vcf_file, bedpe_out):
     header = []
     # dict of BND variant lines that have not yet been matched.
     # variant id is the key
-    unmatched = dict()    
+    unmatched = dict()
 
     for line in vcf_file:
         if in_header:
@@ -299,11 +299,11 @@ def vcfToBedpe(vcf_file, bedpe_out):
             o1 = strands[0]
             o2 = strands[1]
 
-            span = map(int, var.info['CIPOS'].split(','))
+            span = [int(i) for i in var.info['CIPOS'].split(',')]
             s1 = b1 + span[0] - 1
             e1 = b1 + span[1]
 
-            span = map(int, var.info['CIEND'].split(','))
+            span = [int(i) for i in var.info['CIEND'].split(',')]
             s2 = b2 + span[0] - 1
             e2 = b2 + span[1]
 
@@ -315,7 +315,7 @@ def vcfToBedpe(vcf_file, bedpe_out):
                 if int(var.info[ev]) > 0:
                     ev_list.append(ev)
             evtype = ','.join(ev_list)
-                    
+
             format_list = v[8].split(':')
             sample_gt = dict()
             var_sample_list = []
@@ -330,26 +330,24 @@ def vcfToBedpe(vcf_file, bedpe_out):
                     var_sample_list.append(sample_list[i])
                 sample_gt[s] = format_dict
 
-            gt_string = '\t'.join(map(str,[sample_gt[s]['SU'] for s in sample_list]))
+            gt_string = '\t'.join([str(sample_gt[s]['SU']) for s in sample_list])
             support = sum([sample_gt[s]['SU'] for s in sample_list])
 
-            bedpe_out.write('\t'.join(map(str,
-                                          [var.chrom,
-                                           s1,
-                                           e1,
-                                           var.chrom,
-                                           s2,
-                                           e2,
-                                           name,
-                                           var.qual,
-                                           o1,
-                                           o2,
-                                           var.info['SVTYPE'],
-                                           var.filter,
-                                           var.get_info_string(),
-                                           var.get_format_string()])
-                                           + [var.gts[sample].get_gt_string() for sample in var.sample_list]
-                                      ) + '\n')
+            bed_l =[var.chrom,
+                    s1,
+                    e1,
+                    var.chrom,
+                    s2,
+                    e2,
+                    name,
+                    var.qual,
+                    o1,
+                    o2,
+                    var.info['SVTYPE'],
+                    var.filter,
+                    var.get_info_string(),
+                    var.get_format_string()]
+            bedpe_out.write('\t'.join(str(s) for s in bed_l + [var.gts[sample].get_gt_string() for sample in var.sample_list]) + '\n')
 
         else:
             mate_id = var.info['MATEID']
@@ -365,11 +363,11 @@ def vcfToBedpe(vcf_file, bedpe_out):
                 o1 = strands[0]
                 o2 = strands[1]
 
-                span = map(int, prim.info['CIPOS'].split(','))
+                span = [int(i) for i in prim.info['CIPOS'].split(',')]
                 s1 = b1 + span[0] - 1
                 e1 = b1 + span[1]
 
-                span = map(int, sec.info['CIPOS'].split(','))
+                span = [int(i) for i in sec.info['CIPOS'].split(',')]
                 s2 = b2 + span[0] - 1
                 e2 = b2 + span[1]
 
@@ -381,7 +379,7 @@ def vcfToBedpe(vcf_file, bedpe_out):
                     if int(var.info[ev]) > 0:
                         ev_list.append(ev)
                 evtype = ','.join(ev_list)
-                            
+
                 format_list = v[8].split(':')
                 sample_gt = dict()
                 var_sample_list = []
@@ -396,26 +394,25 @@ def vcfToBedpe(vcf_file, bedpe_out):
                         var_sample_list.append(sample_list[i])
                     sample_gt[s] = format_dict
 
-                gt_string = '\t'.join(map(str,[sample_gt[s]['SU'] for s in sample_list]))
+                gt_string = '\t'.join([str(sample_gt[s]['SU']) for s in sample_list])
                 support = sum([sample_gt[s]['SU'] for s in sample_list])
 
-                bedpe_out.write('\t'.join(map(str,
-                                              [prim.chrom,
-                                               s1,
-                                               e1,
-                                               sec.chrom,
-                                               s2,
-                                               e2,
-                                               prim.info['EVENT'],
-                                               prim.qual,
-                                               o1,
-                                               o2,
-                                               prim.info['SVTYPE'],
-                                               prim.filter,
-                                               prim.get_info_string(),
-                                               prim.get_format_string(),
-                                               '\t'.join([prim.gts[sample].get_gt_string() for sample in prim.sample_list])
-                                           ])) + '\n')
+                bed_l = [prim.chrom,
+                         s1,
+                         e1,
+                         sec.chrom,
+                         s2,
+                         e2,
+                         prim.info['EVENT'],
+                         prim.qual,
+                         o1,
+                         o2,
+                         prim.info['SVTYPE'],
+                         prim.filter,
+                         prim.get_info_string(),
+                         prim.get_format_string(),
+                         '\t'.join([prim.gts[sample].get_gt_string() for sample in prim.sample_list])]
+                bedpe_out.write('\t'.join([str(s) for s in bed_l]) + '\n')
 
                 # delete the mate from the dictionary
                 del unmatched[mate_id]
@@ -446,6 +443,6 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
-            raise 
+            raise


### PR DESCRIPTION
This was mostly a question of turning print into print(), replacing the deprecated sets.Set with the built-in set, and replacing things that return an iterator in python3 (as opposed to a list in python2) into lists or list comprehensions.

I tested the code with the test-data mentioned in the readme, I get the same result for python2 and python3, and that is the same result I had before changing the code.