### PR TITLE
dont append when splitting and clean-up gen-vcfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda config --add channels bioconda
-    - conda create -q -n travis python=$TRAVIS_PYTHON_VERSION pysam samtools htslib bedtools
+    - conda create -q -n travis python=$TRAVIS_PYTHON_VERSION samtools htslib bedtools pysam
     - source activate travis
     - git clone https://github.com/hall-lab/svtyper.git
     - sudo cp svtyper/svtyper /usr/local/bin/

--- a/lumpy_tests/test.sh
+++ b/lumpy_tests/test.sh
@@ -132,6 +132,7 @@ wget -nc https://s3.amazonaws.com/lumpy/NA12892.bam
 wget -nc https://s3.amazonaws.com/lumpy/NA12892.bam.bai
 
 rm -f ./*.{disc,split}.bam
+rm -f ./trio*vcf*
 run lumpy_smooth ../../scripts/lumpy_smooth NA12878.bam NA12891.bam NA12892.bam
 assert_exit_code 0 \
 assert_equal \
@@ -148,6 +149,7 @@ assert_exit_code 0
 assert_equal $(grep -c "using existing splitters:" $STDOUT_FILE) 3
 
 assert_equal 5 $(zgrep -cv ^# trio.vcf)
+cat $STDERR_FILE
 assert_equal 5 $(zgrep -cv ^# trio.svtyped.vcf.gz)
 
 cd ..

--- a/scripts/lumpy_smooth
+++ b/scripts/lumpy_smooth
@@ -270,7 +270,7 @@ fi
 export -f BAM_PREP
 echo -en $BAMS  | xargs -I{} -P $THREADS  bash -c "BAM_PREP {}"
 
-export GLOBAL_LUMPY="$LUMPY_HOME/bin/lumpy -mw 4 -t $(mktemp) -tt 0 -P $EXCLUDE "
+export GLOBAL_LUMPY="$LUMPY_HOME/bin/lumpy -mw 4 -t $(mktemp) -tt 0 $EXCLUDE "
 
 for SAMPLE_CSV in ${OPTS[@]:$((OPTIND - 1))}; do
     SAMPLE_ARRAY=(${SAMPLE_CSV//,/ })

--- a/scripts/par-svtyper.sh
+++ b/scripts/par-svtyper.sh
@@ -20,27 +20,29 @@ export -f svtpar
 
 genvcfs() {
     set -euo pipefail
-    bams=$1
-    nth=0
-    tmpvcf=$TMPDIR/tmp.$$.$nth.vcf
-    echo -e "$header" > $tmpvcf
-    k=0
+    lines=$1
+    vcf=$2
+    set +e
+    header="$(less $vcf | head -2000 | grep ^#)"
+    set -e
     # run this once to force the calculation of the bam stats.
     # this avoids a race condition.
-    svtpar <(echo -e "$header")
-    while read -r line || [[ -n "$line" ]]; do
-        k=$((k + 1))
-        echo -e "$line" >> $tmpvcf
-        if [[ "$k" -eq "$LINES" ]]; then
-            # echo the bam and the vcf so they can be sent to svtyper.
-            echo "$tmpvcf"
-            nth=$((nth + 1))
-            tmpvcf=$TMPDIR/tmp.$$.$nth.vcf
-            echo -e "$header" > $tmpvcf
-            k=0;
-        fi 
-    done < "$vcf"
-    echo "$tmpvcf"
+
+    zless "$vcf" | awk -vtmp=$TMPDIR -vtmpvcf="$TMPDIR/0.tmp.$$.vcf" -vpid=$$ -v header="$header"  -vLINES=$lines 'BEGIN{nth=1;} !((NR - 1) % LINES) {
+        # we print the tmpvcf and move onto the next.
+        if(NR > 1) {
+            print tmpvcf;
+        }
+        tmpvcf=tmp"/"nth".tmp."pid".vcf.gz"
+        print header > tmpvcf;
+        nth+=1;
+    }
+    {
+        print $0 > tmpvcf;
+    }
+    END {
+        print tmpvcf;
+    }' 
 }
 
 vcfsort() {
@@ -56,7 +58,7 @@ fi
 export mypid=$$
 
 cleanup() {
-   rm -f $TMPDIR/tmp.$mypid.*.vcf
+   rm -f $TMPDIR/*.$mypid.vcf*
    rm -f $TMPDIR/tmp.$mypid.*.lib
 }
 
@@ -78,7 +80,8 @@ type gargs >/dev/null 2>&1 || {
 psvtyper() {
     set -euo pipefail
     export header=$(head -2000 $vcf | grep ^#)
-    genvcfs $bams | gargs -p $THREADS "svtpar {}" | vcfsort
+    svtpar <(echo -e "$header")
+    genvcfs $LINES $vcf | gargs -p $THREADS "svtpar {}" | vcfsort
 }
 
 mkdir -p $TMPDIR


### PR DESCRIPTION
this also remove the `-P` from the call to lumpy.