### PR TITLE
Changes to get NM in output BAM.

### DIFF
--- a/src/filter/filter.c
+++ b/src/filter/filter.c
@@ -227,10 +227,10 @@ int main(int argc, char **argv)
     }
 
     bam_hdr_t *hdr = sam_hdr_read(in);
-    // 0x1 | 0x2 | 0x4 | 0x8 | 0x10 | 0x20 | 0x40 | 0x80 | 0x100 | 0x800
-    // decode everything but base-seq and base-qual
-    hts_set_opt(in, CRAM_OPT_REQUIRED_FIELDS, 2559);
-    hts_set_opt(in, CRAM_OPT_DECODE_MD, 0);
+    // 0x1 | 0x2 | 0x4 | 0x8 | 0x10 | 0x20 | 0x40 | 0x80 | 0x100 | 0x200 | 0x800
+    // decode everything but base-qual
+    hts_set_opt(in, CRAM_OPT_REQUIRED_FIELDS, 3071);
+    hts_set_opt(in, CRAM_OPT_DECODE_MD, 1);
 
     int r = sam_hdr_write(disc, hdr);
     r = sam_hdr_write(split, hdr);


### PR DESCRIPTION
@brentp - The existing code doesn't report the number of mismatches from CRAM files.

This appears to be because they are calculated dynamically and tied to the decoding of the read sequence and the MD tag.

See https://github.com/samtools/htslib/blob/develop/cram/cram_decode.c#L1214-L1215
and
https://github.com/samtools/htslib/blob/develop/cram/cram_decode.c#L1214-L1215

I'm somewhat guessing here, but only enabling MD5 decoding segfaults and adding in both seems to get the job done.

