### PR TITLE
Change inline functions to static inline

### DIFF
--- a/src/filter/filter.c
+++ b/src/filter/filter.c
@@ -28,14 +28,14 @@ struct line {
 
 
 // from Dave Larson's extract_sv_reads
-inline size_t _pre_seq_bytes(bam1_t const* b) {
+static inline size_t _pre_seq_bytes(bam1_t const* b) {
 	return (b->core.n_cigar<<2) + b->core.l_qname;
 }
-inline size_t _seq_qual_bytes(bam1_t const* b) {
+static inline size_t _seq_qual_bytes(bam1_t const* b) {
 	// sequence bytes + quality bytes
 	return (((b->core.l_qseq + 1)>>1) + b->core.l_qseq);
 }
-inline size_t _post_qual_bytes(bam1_t const* b) {
+static inline size_t _post_qual_bytes(bam1_t const* b) {
 	// Total - pre-sequence bytes - sequence bytes - quality bytes
 	return (b->l_data - _pre_seq_bytes(b) - _seq_qual_bytes(b));
 }


### PR DESCRIPTION
When compiling this with gcc , I'm seeing errors like:
```
/tmp/ccygajQG.o: In function `drop_seq_qual':
filter.c:(.text+0x3d): undefined reference to `_pre_seq_bytes'
filter.c:(.text+0x63): undefined reference to `_post_qual_bytes'
filter.c:(.text+0xb5): undefined reference to `_pre_seq_bytes'
filter.c:(.text+0x128): undefined reference to `_seq_qual_bytes'
```

Based on [this](https://stackoverflow.com/questions/19068705/undefined-reference-when-calling-inline-function), I changed these to static and the error is gone. Since I don't believe we intend these functions to be called outside this file, I think this is a safe change.

cc @brentp @ryanlayer 