### PR TITLE
Work-around for lumpy segfaults from lumpyexpress

### DIFF
--- a/scripts/lumpyexpress
+++ b/scripts/lumpyexpress
@@ -183,7 +183,7 @@ do
 	x)
 	    EXCLUDE_BED="$OPTARG"
 	    EXCLUDE_BED_FMT="-x $EXCLUDE_BED"
-	    ;;  
+	    ;;
 	T)
 	    TEMP_DIR="$OPTARG"
 	    ;;
@@ -438,7 +438,7 @@ then
 	    mv ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).discordants.bam ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).discordants.bam
 	    mv ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).splitters.bam ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).splitters.bam
 	fi
-	    
+
 	# update the splitters and discordant BAM lists
 	SPL_BAM_LIST+=(${TEMP_DIR}/$OUTBASE.sample$(($i+1)).splitters.bam)
 	DISC_BAM_LIST+=(${TEMP_DIR}/$OUTBASE.sample$(($i+1)).discordants.bam)
@@ -500,10 +500,7 @@ else
 	    STDEV=`cat ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).insert.stats | tr '\t' '\n' | grep "^stdev" | sed 's/stdev\://g'`
 	    RG_STRING=`echo "${LIB_RG_LIST[$j]}" | sed 's/,/,read_group:/g' | sed 's/^/read_group:/g'`
 
-	    if [[ "$MEAN" != "NA" ]] && [[ "$STDEV" != "NA" ]]
-	    then
-		LUMPY_DISC_STRING="$LUMPY_DISC_STRING -pe bam_file:${DISC_BAM},histo_file:${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).x4.histo,mean:${MEAN},stdev:${STDEV},read_length:${LIB_READ_LENGTH_LIST[$j]},min_non_overlap:${LIB_READ_LENGTH_LIST[$j]},discordant_z:5,back_distance:10,weight:1,id:${DISC_SAMPLE},min_mapping_threshold:20,${RG_STRING}"
-	    fi
+	    LUMPY_DISC_STRING="$LUMPY_DISC_STRING -pe bam_file:${DISC_BAM},histo_file:${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).x4.histo,mean:${MEAN},stdev:${STDEV},read_length:${LIB_READ_LENGTH_LIST[$j]},min_non_overlap:${LIB_READ_LENGTH_LIST[$j]},discordant_z:5,back_distance:10,weight:1,id:${DISC_SAMPLE},min_mapping_threshold:20,${RG_STRING}"
 	done
     done
 fi

--- a/scripts/pairend_distro.py
+++ b/scripts/pairend_distro.py
@@ -112,41 +112,38 @@ for l in sys.stdin:
 min_elements = 1000
 if len(L) < min_elements:
     sys.stderr.write("Warning: only %s elements in distribution (min: %s)\n" % (len(L), min_elements))
-    mean = "NA"
-    stdev = "NA"
 
-else:
-    # Remove outliers
-    med, umad = unscaled_upper_mad(L)
-    upper_cutoff = med + options.mads * umad
-    L = [v for v in L if v < upper_cutoff]
-    new_len = len(L)
-    removed = c - new_len
-    sys.stderr.write("Removed %d outliers with isize >= %d\n" %
-        (removed, upper_cutoff))
-    c = new_len
+# Remove outliers
+med, umad = unscaled_upper_mad(L)
+upper_cutoff = med + options.mads * umad
+L = [v for v in L if v < upper_cutoff]
+new_len = len(L)
+removed = c - new_len
+sys.stderr.write("Removed %d outliers with isize >= %d\n" %
+    (removed, upper_cutoff))
+c = new_len
 
-    mean, stdev = mean_std(L)
+mean, stdev = mean_std(L)
 
-    start = options.read_length
-    end = int(mean + options.X*stdev)
+start = options.read_length
+end = int(mean + options.X*stdev)
 
-    H = [0] * (end - start + 1)
-    s = 0
+H = [0] * (end - start + 1)
+s = 0
 
-    for x in L:
-        if (x >= start) and (x <= end):
-            j = int(x - start)
-            H[j] = H[ int(x - start) ] + 1
-            s += 1
+for x in L:
+    if (x >= start) and (x <= end):
+        j = int(x - start)
+        H[j] = H[ int(x - start) ] + 1
+        s += 1
 
-    f = open(options.output_file, 'w')
+f = open(options.output_file, 'w')
 
-    for i in range(end - start):
-        o = str(i) + "\t" + str(float(H[i])/float(s)) + "\n"
-        f.write(o)
+for i in range(end - start):
+    o = str(i) + "\t" + str(float(H[i])/float(s)) + "\n"
+    f.write(o)
 
 
-    f.close()
+f.close()
 
 print(('mean:' + str(mean) + '\tstdev:' + str(stdev)))


### PR DESCRIPTION
I have not tested these changes from this fork, but I have tested them from editing my conda install's lumpyexpress script to not omit any -pe flags and by manually supplying a mean & stdev calculated by lumpyexpress from version 0.2.13 from homebrew...



The call to lumpy from lumpyexpress segfaults when the -pe flags are omitted when the insert mean and stdev are not calculated in lumpyexpress. Furthermore, the lumpy galaxy wrapper fails with an error that mean & stdev are missing.

I kept the warning, but allowed mean and stdev to be output in all cases to avoid the segfaults from lumpyexpress and avoid the error & no output from the lumpy galaxy wrapper.

This is admittedly a work-around. Lumpy should probably be edited to be able to not segfault when the -pe discordant options are missing and should gracefully output no results if mean and stdev do not have valid values.

Files checked in: scripts/lumpyexpress scripts/pairend_distro.py